### PR TITLE
Add ability to set the bonus cap reward as deferred to the next rollover

### DIFF
--- a/ZFLBot/IDataService.cs
+++ b/ZFLBot/IDataService.cs
@@ -14,7 +14,7 @@ internal interface IDataService
 
     TeamInfo SpendCAP(ulong discordUserId, int spend, string reason);
 
-    TeamInfo AddBonusCAP(ulong discordUserId, int amount, string reason);
+    TeamInfo AddBonusCAP(ulong discordUserId, int amount, string reason, bool isDeferred = false);
 
     TeamInfo GridironInvestment(ulong discordUserId, int spend);
 
@@ -119,11 +119,11 @@ internal class Tracker(string key, string value){
   public string Value => value;
 }
 
-internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carryover, int gridironInvestment, IReadOnlyList<TeamAction> actions, ulong statusMessageId, List<Demand> demands, string noteText)
+internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carryover, int gridironInvestment, IReadOnlyList<TeamAction> actions, ulong statusMessageId, List<Demand> demands, string noteText, IReadOnlyList<TeamAction> deferredActions)
 {
     public static TeamInfo Create(string teamName, int div, int weeklyAllowance)
     {
-        return new TeamInfo(teamName, div, weeklyAllowance, 0, 0, [], 0, [], "");
+        return new TeamInfo(teamName, div, weeklyAllowance, 0, 0, [], 0, [], "", []);
     }
 
     public string Id => teamName.Replace(' ', '_').Trim().ToLower();
@@ -135,6 +135,8 @@ internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carry
     public int Division => div;
 
     public IReadOnlyList<TeamAction> Actions => actions;
+
+    public IReadOnlyList<TeamAction> DeferredActions => deferredActions;
 
     public int CurrentCAP => carryover + weeklyAllowance + actions.Select(a => a.CAPDelta).Sum();
 
@@ -156,7 +158,7 @@ internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carry
 
     public TeamInfo UpdateNote(string note)
     {
-      return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, actions, statusMessageId, demands, note);
+      return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, actions, statusMessageId, demands, note, deferredActions);
     }
 
     public TeamInfo WithCAPSpent(int spend, string reason)
@@ -166,21 +168,25 @@ internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carry
             throw new ArgumentException("Overspend!");
         }
 
-        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, [.. actions, new(ActionType.CAPSpend, -spend, 0, reason)], statusMessageId, demands, noteText);
+        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, [.. actions, new(ActionType.CAPSpend, -spend, 0, reason)], statusMessageId, demands, noteText, deferredActions);
     }
 
-    public TeamInfo WithAddedBonusCAP(int amount, string reason)
+    public TeamInfo WithAddedBonusCAP(int amount, string reason, bool isDeferred)
     {
-        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, [.. actions, new(ActionType.BonusCAP, amount, 0, reason)], statusMessageId, demands, noteText);
+      if (isDeferred)
+        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, actions, statusMessageId, demands, noteText, [.. deferredActions, new(ActionType.BonusCAP, amount, 0, reason)]);
+      else
+        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, [.. actions, new(ActionType.BonusCAP, amount, 0, reason)], statusMessageId, demands, noteText, deferredActions);
     }
 
     public TeamInfo WithSpentCAPReset()
     {
         var newActions = actions.Where(a => a.Type == ActionType.BonusCAP).ToList();
+        var newDeferredActions = deferredActions.Where(a => a.Type == ActionType.BonusCAP).ToList();
         var investmentThisRound = actions.Where(a => a.Type == ActionType.GridironInvestment).Select(a => -a.CAPDelta).Sum();
         var gridironSpentThisRound = actions.Where(a => a.Type == ActionType.GridironSpend).Select(a => -a.GridironDelta).Sum();
         Debug.Assert(gridironInvestment >= investmentThisRound);
-        return new TeamInfo(teamName, div, weeklyAllowance, carryover, gridironInvestment - investmentThisRound + gridironSpentThisRound, newActions, statusMessageId, demands, noteText);
+        return new TeamInfo(teamName, div, weeklyAllowance, carryover, gridironInvestment - investmentThisRound + gridironSpentThisRound, newActions, statusMessageId, demands, noteText, newDeferredActions);
     }
 
     public TeamInfo WithGridironInvestment(int spend)
@@ -190,7 +196,7 @@ internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carry
             throw new ArgumentException("Overspend!");
         }
 
-        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment + spend, [.. actions, new(ActionType.GridironInvestment, -spend, spend, "Gridiron Investment")], statusMessageId, demands, noteText);
+        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment + spend, [.. actions, new(ActionType.GridironInvestment, -spend, spend, "Gridiron Investment")], statusMessageId, demands, noteText, deferredActions);
     }
 
     public TeamInfo WithGridironCAPSpent(int amount, string reason)
@@ -200,12 +206,12 @@ internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carry
             throw new ArgumentException("Overspend!");
         }
 
-        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment - amount, [.. actions, new(ActionType.GridironSpend, 0, -amount, reason)], statusMessageId, demands, noteText);
+        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment - amount, [.. actions, new(ActionType.GridironSpend, 0, -amount, reason)], statusMessageId, demands, noteText, deferredActions);
     }
 
     public TeamInfo WithNewStatusMessage(ulong messageId)
     {
-        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, actions, messageId, demands, noteText);
+        return new(teamName, div, weeklyAllowance, carryover, gridironInvestment, actions, messageId, demands, noteText, deferredActions);
     }
 
     public TeamInfo Rollover()
@@ -218,6 +224,6 @@ internal class TeamInfo(string teamName, int div, int weeklyAllowance, int carry
         var lostCAP = Math.Max(this.TotalWeeklyAllowance, this.SpentCAP);
         var newCarryover = allGainedCAP - lostCAP;
 
-        return new(teamName, div, weeklyAllowance, newCarryover, gridironInvestment, [], statusMessageId, demands, noteText);
+        return new(teamName, div, weeklyAllowance, newCarryover, gridironInvestment, deferredActions, statusMessageId, demands, noteText, []);
     }
 }

--- a/ZFLBot/JsonDataService.cs
+++ b/ZFLBot/JsonDataService.cs
@@ -216,7 +216,7 @@ internal class JsonDataService : IDataService, IDisposable
     }
 
     /// <inheritdoc />
-    public TeamInfo AddBonusCAP(ulong discordUserId, int amount, string reason)
+    public TeamInfo AddBonusCAP(ulong discordUserId, int amount, string reason, bool isDeferred = false)
     {
         TeamInfo teamInfo;
         lock (this.lck)
@@ -226,7 +226,7 @@ internal class JsonDataService : IDataService, IDisposable
                 return null;
             }
 
-            teamInfo = teamInfo.WithAddedBonusCAP(amount, reason);
+            teamInfo = teamInfo.WithAddedBonusCAP(amount, reason, isDeferred);
             this.teams[discordUserId] = teamInfo;
             this.flushRequested = true;
         }
@@ -545,6 +545,7 @@ internal class JsonDataService : IDataService, IDisposable
             Carryover = teamInfo.Carryover,
             GridironInvestment = teamInfo.GridironInvestment,
             Actions = teamInfo.Actions?.Select(SerializedTeamAction.FromTeamAction).ToArray() ?? [],
+            DeferredActions = teamInfo.DeferredActions?.Select(SerializedTeamAction.FromTeamAction).ToArray() ?? [],
             StatusMessageId = teamInfo.StatusMessageId,
             Demands = teamInfo.Demands?.Select(SerializedDemand.FromDemand).ToArray() ?? [],
             NoteText = teamInfo.NoteText,
@@ -561,6 +562,7 @@ internal class JsonDataService : IDataService, IDisposable
         public int GridironInvestment;
 
         public SerializedTeamAction[] Actions;
+        public SerializedTeamAction[] DeferredActions;
 
         public ulong StatusMessageId;
 
@@ -568,6 +570,6 @@ internal class JsonDataService : IDataService, IDisposable
 
         public string NoteText;
 
-        public TeamInfo ToTeamInfo() => new(this.TeamName, this.Division, this.WeeklyAllowance, this.Carryover, this.GridironInvestment, this.Actions?.Select(a => a.ToTeamAction()).ToList() ?? [], this.StatusMessageId, this.Demands?.Select(d => d.ToDemand()).ToList() ?? [], this.NoteText != null ? this.NoteText.Substring(0, Math.Min(this.NoteText.Length, 1700)) : "");
+        public TeamInfo ToTeamInfo() => new(this.TeamName, this.Division, this.WeeklyAllowance, this.Carryover, this.GridironInvestment, this.Actions?.Select(a => a.ToTeamAction()).ToList() ?? [], this.StatusMessageId, this.Demands?.Select(d => d.ToDemand()).ToList() ?? [], this.NoteText != null ? this.NoteText.Substring(0, Math.Min(this.NoteText.Length, 1700)) : "", this.DeferredActions?.Select(a => a.ToTeamAction()).ToList() ?? []);
     }
 }

--- a/ZFLBot/ZFLBot.Commands.cs
+++ b/ZFLBot/ZFLBot.Commands.cs
@@ -69,7 +69,8 @@ internal partial class ZFLBot
                             .WithDescription("Adds bonus CAP to a team")
                             .AddOption("coach", ApplicationCommandOptionType.User, "The coach", isRequired: true)
                             .AddOption("amount", ApplicationCommandOptionType.Integer, "The amount of CAP", isRequired: true)
-                            .AddOption("reason", ApplicationCommandOptionType.String, "The reason for the addition", isRequired: true))
+                            .AddOption("reason", ApplicationCommandOptionType.String, "The reason for the addition", isRequired: true)
+                            .AddOption("is-deferred", ApplicationCommandOptionType.Boolean, "If the CAP is deferred to the next round", isRequired: false, choices: new ApplicationCommandOptionChoiceProperties[]{ new ApplicationCommandOptionChoiceProperties {Name = "No", Value = "false"}, new ApplicationCommandOptionChoiceProperties {Name = "Yes", Value = "true"} }))
                     .AddOption(
                         new SlashCommandOptionBuilder()
                             .WithName("use-gridiron-cap")
@@ -352,10 +353,12 @@ internal partial class ZFLBot
                 var coachArg = cmd.GetOption("coach")!;
                 var amountArg = cmd.GetOption("amount")!;
                 var reasonArg = cmd.GetOption("reason")!; 
+                var isDeferredArg = cmd.GetOption("is-deferred")!; 
                 var user = (SocketGuildUser)coachArg.Value;
                 var amount = (long)amountArg.Value;
                 var reason = (string) reasonArg.Value;
-                await this.AddBonusCAP(arg, user, (int)amount, reason);
+                var isDeferred = (bool?) isDeferredArg?.Value;
+                await this.AddBonusCAP(arg, user, (int)amount, reason, isDeferred ?? false);
                 break;
             }
 
@@ -491,7 +494,7 @@ internal partial class ZFLBot
         }
     }
 
-    private async Task AddBonusCAP(SocketSlashCommand arg, SocketGuildUser user, int amount, string reason)
+    private async Task AddBonusCAP(SocketSlashCommand arg, SocketGuildUser user, int amount, string reason, bool isDeferred)
     {
         var guildId = arg.GuildId.GetValueOrDefault();
 
@@ -507,11 +510,11 @@ internal partial class ZFLBot
             return;
         }
 
-        await arg.RespondAsync($"Giving {user.Username} ({teamInfo.TeamName}) {amount} bonus CAP", ephemeral: true);
-        await this.AuditLog(guildId, $"{arg.User.Username} ({arg.User.Id}) gave {user.Username} ({user.Id}) ({teamInfo.TeamName}) {amount} bonus CAP: \"{reason}\"");
-        teamInfo = this.dataServices[guildId].AddBonusCAP(user.Id, amount, reason);
+        await arg.RespondAsync($"Giving {user.Username} ({teamInfo.TeamName}) {amount} bonus CAP{(isDeferred ? " next round" : "")}", ephemeral: true);
+        await this.AuditLog(guildId, $"{arg.User.Username} ({arg.User.Id}) gave {user.Username} ({user.Id}) ({teamInfo.TeamName}) {amount} bonus CAP{(isDeferred ? " for next round" : "")}: \"{reason}\"");
+        teamInfo = this.dataServices[guildId].AddBonusCAP(user.Id, amount, reason, isDeferred);
         await this.UpdateStatusMessage(guildId, user.Id, teamInfo);
-        if (amount > 0)
+        if (amount > 0 && !isDeferred)
         {
             try
             {
@@ -685,6 +688,25 @@ internal partial class ZFLBot
             }
 
             builder.Append($" - {action.Reason}");
+        }
+
+        if (teamInfo.DeferredActions.Count() > 0)
+        {
+          builder.Append($"\n### Deferred actions for next round");
+          foreach (var action in teamInfo.DeferredActions)
+          {
+            builder.Append("\n* ");
+            if (action.UnixTimeStamp > 0)
+            {
+              builder.Append($"<t:{action.UnixTimeStamp}:d>: ");
+            }
+
+            if (action.CAPDelta != 0)
+            {
+              builder.Append($"{action.CAPDelta:+#;-#;0} CAP");
+            }
+            builder.Append($" - {action.Reason}");
+          }
         }
 
         if (message != null)


### PR DESCRIPTION
Admins will be able to set the "is-deferred" flag on the /admin add-bonus-cap command which will put the action in a new action array stored in the TeamInfo.
Deferred actions does not create a new DM to the coach and does not count towards their CAP pool for the round. Upon rollover the deferred array will be copied over to the new actions array for the round and will also reset the deferred array, which in practice means that you can only defer an action for one round.